### PR TITLE
Add method to produce public (no-login) link for a job

### DIFF
--- a/lib/sauce_whisk.rb
+++ b/lib/sauce_whisk.rb
@@ -41,4 +41,11 @@ module SauceWhisk
   def self.logger
     @logger||= STDOUT
   end
+
+  def self.public_link(job_id)
+    key        = "#{self.username}:#{self.password}"
+    auth_token = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('md5'), key, job_id)
+
+    "https://saucelabs.com/jobs/#{job_id}?auth=#{auth_token}"
+  end
 end


### PR DESCRIPTION
A class method is added to take the id of a job and return the authenticated public link for that job on Sauce Labs' site. This will be used by RSpec and Cucumber clients to display the link on failure.
