### PR TITLE
Fix changelog markdown

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,7 +1,9 @@
 # Major Version 0
+
 ### 0.0.13
 * Sauce storage support added (Thanks @bootstraponline)
 * Various gem build quality fixes (Thanks @bootstraponline)
+
 ### 0.0.12
 * Added additional minute types
 
@@ -10,6 +12,7 @@
 
 ### 0.0.6
 * Correct RestClient -- Actually require it
+
 ### 0.0.5
 * Added Sauce class
 


### PR DESCRIPTION
GitHub flavored markdown expects newlines.
