### PR TITLE
Allow rest-client dependency to be 1.8

### DIFF
--- a/sauce_whisk.gemspec
+++ b/sauce_whisk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.license = 'MIT'
 
-  gem.add_runtime_dependency 'rest-client', '~> 1.7.1'
+  gem.add_runtime_dependency 'rest-client', '~> 1.7'
   gem.add_runtime_dependency 'json', '~> 1.8.1'
   gem.add_development_dependency 'vcr', '~> 2.9.0'
   gem.add_development_dependency 'webmock', '~> 1.18.0'


### PR DESCRIPTION
Loosens the dependency on rest-client to allow 1.8.0 to be installed as per recent security update.

Fixes https://github.com/saucelabs/sauce_whisk/issues/42.

