### PR TITLE
Patch job attribute custom_data to send custom-data over the wire

### DIFF
--- a/lib/sauce_whisk/jobs.rb
+++ b/lib/sauce_whisk/jobs.rb
@@ -31,7 +31,11 @@ module SauceWhisk
 
     def self.save(job)
       fields_to_save = job.updated_fields.each_with_object(Hash.new) do |field, hsh|
-        hsh[field] = job.send(field.to_s)
+        if field == :custom_data
+          hsh[:'custom-data'] = job.send(field.to_s)
+        else
+          hsh[field] = job.send(field.to_s)
+        end
       end
       put job.id, fields_to_save.to_json
     end

--- a/spec/lib/sauce_whisk/jobs_spec.rb
+++ b/spec/lib/sauce_whisk/jobs_spec.rb
@@ -62,6 +62,15 @@ describe SauceWhisk::Jobs do
       expected_body = {:name => "Updated Name"}.to_json
       assert_requested :put, "https://#{auth}@saucelabs.com/rest/v1/#{user}/jobs/#{job.id}", :body => expected_body
     end
+
+    it "sends custom-data with hyphen", :focus => true do
+      job_id = "bd9c43dd6b5549f1b942d1d581d98cac"
+      job = SauceWhisk::Job.new({:id => job_id})
+      job.custom_data = {:key => "value"}
+      SauceWhisk::Jobs.save (job)
+      expected_body = {:'custom-data' => {:key => "value"}}.to_json
+      assert_requested :put, "https://#{auth}@saucelabs.com/rest/v1/#{user}/jobs/#{job.id}", :body => expected_body
+    end
   end
 
   describe "##fetch", :vcr => {:cassette_name => "jobs"} do


### PR DESCRIPTION
Problem isolated while pairing with Jeff Schomay<jschomay@gmail.com>

Jeff and I found that Whisk is unable to set the custom_data attribute on Jobs. The Sauce REST API accepts the field custom-data, but Whisk was sending custom_data.  So, we've added a test and a proposed fix.

Relevant API Docs: https://docs.saucelabs.com/reference/rest-api/#update-job