### PR TITLE
Exclude specs from build gem to speed install.

### DIFF
--- a/sauce_whisk.gemspec
+++ b/sauce_whisk.gemspec
@@ -12,9 +12,8 @@ Gem::Specification.new do |gem|
   gem.summary     = "Sauce_Whisk lets you mix extra data into your Sauce test results!\nFetch and update Job details, screenshots, videos and logs."
   gem.homepage    = 'http://www.github.com/dylanlacey/sauce_whisk'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($/).reject { |e| /spec/.match e }
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
   gem.license = 'MIT'


### PR DESCRIPTION
`gem.test-files` is not documented and a hypersearch of the digital
meganet shows that it maybe never did anything and probably doesn't
know.

All the data in `spec/fixtures` is _super_ slow to download so our tiny
widdle gem takes longer then almost anything else to fetch, for a
use-case many/most? users don't have: Running unit tests on install.

This change removes `gem.test-files` and also excludes the `spec`
directory from the gem when build.