### PR TITLE
Loosen dependencies so apps can drive dependency resolution

### DIFF
--- a/sauce_whisk.gemspec
+++ b/sauce_whisk.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.license = 'MIT'
 
-  gem.add_runtime_dependency 'rest-client', '~> 1.8.0'
-  gem.add_runtime_dependency 'json', '~> 1.8.1'
-  gem.add_development_dependency 'vcr', '~> 2.9.0'
-  gem.add_development_dependency 'webmock', '~> 1.21.0'
-  gem.add_development_dependency 'rspec', '~> 3.3.0'
-  gem.add_development_dependency 'rake', '~> 10.4.2'
+  gem.add_runtime_dependency 'rest-client', '>= 1.8'
+  gem.add_runtime_dependency 'json', '>= 1.8'
+  gem.add_development_dependency 'vcr', '~> 2.9'
+  gem.add_development_dependency 'webmock', '~> 1.21'
+  gem.add_development_dependency 'rspec', '~> 3.3'
+  gem.add_development_dependency 'rake', '>= 10.4'
 end


### PR DESCRIPTION
Strict deps on teeny versions leaves little leeway for apps to upgrade.
Prefer to stick to minor versions for most libraries (at some risk of
rare breakage!) and use very loose minimum bounds for very common
libraries with rare API changes, like Rake and JSON.

Currently, bringing SauceWhisk into a project causes cascading
downgrades of the libraries it depends on *and* causes downgrades of the
libraries that depend on *those*. For example, the strict dep on
rest-client results in a strict dep on old mime-types, disallowing
use of mime-types 3 and later.

This sort of unanticipated cascade effect is a good reason for libraries
to err on the liberal side with their own dependencies, avoiding lock-in
when multiple libraries get very specific with their deps, leaving
little room for drift.