### PR TITLE
Updates SauceWhisk.load_first_found

### DIFF
--- a/lib/sauce_whisk.rb
+++ b/lib/sauce_whisk.rb
@@ -113,7 +113,7 @@ module SauceWhisk
     value = self.instance_variable_get "@#{key}".to_sym
 
     unless value
-      value = ::Sauce::Config.new[key] if defined? ::Sauce
+      value = ::Sauce::Config.new[key] if defined? ::Sauce::Config
     end
 
     value = self.from_yml(key) unless value


### PR DESCRIPTION
### Description
Updates `SauceWhisk.load_first_found` to check for the `Sauce::Config` constant,
instead of `Sauce`. This will help prevent against accidental collisions with
`Sauce` namespaces not provided by the (deprecated) Sauce gem.

I ran into this while grouping some of my other Sauce utility classes under the `Sauce`
namespace, which makes the current version of SauceWhisk think a `Sauce::Config`
class exists.

### Risks
**Low**: Increases the specificity of assumptions (that a `Sauce::Config` class exists.)