### PR TITLE
Provides visibility over tunnel identifier

### DIFF
--- a/lib/sauce_whisk/tunnels.rb
+++ b/lib/sauce_whisk/tunnels.rb
@@ -49,7 +49,7 @@ module SauceWhisk
   end
 
   class Tunnel
-    attr_reader :id, :owner, :status, :host, :creation_time, :ssh_port
+    attr_reader :id, :owner, :status, :host, :creation_time, :ssh_port, :tunnel_identifier
 
     def initialize(params)
       params.each do |param, val|

--- a/spec/lib/sauce_whisk/tunnel_spec.rb
+++ b/spec/lib/sauce_whisk/tunnel_spec.rb
@@ -6,7 +6,8 @@ describe SauceWhisk::Tunnel do
     :owner  => "test_user",
     :status => "open",
     :host => "yacko.wacko.dot",
-    :creation_time => Time.now
+    :creation_time => Time.now,
+    :tunnel_identifier => "tunnel_identifier"
   }}
 
   describe "#new" do
@@ -17,6 +18,7 @@ describe SauceWhisk::Tunnel do
       expect( tunnel.status ).to eq "open"
       expect( tunnel.host ).to eq "yacko.wacko.dot"
       expect( tunnel.creation_time ).to eq params[:creation_time]
+      expect( tunnel.tunnel_identifier ).to eq params[:tunnel_identifier]
     end
   end
 


### PR DESCRIPTION
Hello!

I'm trying to prevent opening the same tunnel from the same machine twice. For that I'm using `-i` when opening the tunnel via the SauceProxy terminal tool. The REST API returns this value as `tunnel_identifier`.

But the problem is that `sauce_whisk` provides no visibility over it. So I've simply added it as another read-only attribute.

I've updated the tunnel spec and looks I haven't broken anything else (yay for me).

Hope it makes sense, any questions please let me know.

Thanks!