### PR TITLE
Saucelabs gem is deprecated

### DIFF
--- a/lib/sauce_whisk.rb
+++ b/lib/sauce_whisk.rb
@@ -110,20 +110,9 @@ module SauceWhisk
   end
 
   def self.load_first_found(key)
-    value = self.instance_variable_get "@#{key}".to_sym
-
-    unless value
-      value = ::Sauce::Config.new[key] if defined? ::Sauce
-    end
-
-    value = self.from_yml(key) unless value
-    
-    unless value
-      env_key = "SAUCE_#{key.to_s.upcase}" 
-      value = ENV[env_key]
-    end
-    
-    return value
+    self.instance_variable_get "@#{key}".to_sym ||
+                                   self.from_yml(key) ||
+                                   ENV["SAUCE_#{key.to_s.upcase}"]
   end
 
   class JobNotComplete < StandardError


### PR DESCRIPTION
This is actually giving a name space collision with what I'm doing in Saucer gem.

An alternative to just deleting this is to:

```
unless value && !Bundler.definition.specs.map(&:name).include?('sauce_ruby')
  value = ::Sauce::Config.new[key]
end
```